### PR TITLE
Changes for prometheus kafka exporter rollout 

### DIFF
--- a/groups/kafka/locals.tf
+++ b/groups/kafka/locals.tf
@@ -83,9 +83,7 @@ locals {
     cidr_blocks: concat(
       local.placement_subnet_cidrs
     )
-    list_ids: [
-      data.aws_ec2_managed_prefix_list.administration.id
-    ]
+    list_ids: []
   }
 
 }

--- a/groups/kafka/main.tf
+++ b/groups/kafka/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 module "kafka" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/kafka?ref=tags/1.0.143"
+  source = "git@github.com:companieshouse/terraform-modules//aws/kafka?ref=tags/1.0.154"
 
   ami_owner_id                    = local.ami_owner_id
   debug                           = var.debug

--- a/groups/kafka/main.tf
+++ b/groups/kafka/main.tf
@@ -11,7 +11,7 @@ terraform {
 }
 
 module "kafka" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/kafka?ref=tags/1.0.154"
+  source = "git@github.com:companieshouse/terraform-modules//aws/kafka?ref=tags/1.0.158"
 
   ami_owner_id                    = local.ami_owner_id
   debug                           = var.debug
@@ -21,6 +21,7 @@ module "kafka" {
   dns_zone_name                   = local.dns_zone_name
   environment                     = var.environment
   instance_specifications         = var.instance_specifications
+  instance_template_path          = "${path.root}/instance-templates/kafka"
   kafka_broker_access             = local.kafka_broker_access
   kafka_zookeeper_connect_string  = local.kafka_zookeeper_connect_string
   lvm_block_definitions           = var.lvm_block_definitions

--- a/groups/kafka/profiles/development-eu-west-2/devops2/vars
+++ b/groups/kafka/profiles/development-eu-west-2/devops2/vars
@@ -1,0 +1,31 @@
+account_name = "development"
+environment = "devops2"
+
+instance_specifications = {
+  "eu-west-2a" = {
+    "1" = {
+      ami_version_pattern = "feature"
+    }
+  }
+  "eu-west-2b" = {
+    "2" = {
+      ami_version_pattern = "feature"
+    }
+  }
+  "eu-west-2c" = {
+    "3" = {
+      ami_version_pattern = "feature"
+    }
+  }
+}
+
+lvm_block_definitions = [
+  {
+    aws_volume_size_gb: "100",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/kafka/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }
+]
+
+route53_available = true

--- a/groups/kafka/profiles/development-eu-west-2/devops2/vars
+++ b/groups/kafka/profiles/development-eu-west-2/devops2/vars
@@ -3,19 +3,13 @@ environment = "devops2"
 
 instance_specifications = {
   "eu-west-2a" = {
-    "1" = {
-      ami_version_pattern = "feature"
-    }
+    "1" = {}
   }
   "eu-west-2b" = {
-    "2" = {
-      ami_version_pattern = "feature"
-    }
+    "2" = {}
   }
   "eu-west-2c" = {
-    "3" = {
-      ami_version_pattern = "feature"
-    }
+    "3" = {}
   }
 }
 

--- a/groups/shared/profiles/development-eu-west-2/devops2/vars
+++ b/groups/shared/profiles/development-eu-west-2/devops2/vars
@@ -1,0 +1,2 @@
+account_name = "development"
+environment = "devops2"

--- a/groups/zookeeper/profiles/development-eu-west-2/devops2/vars
+++ b/groups/zookeeper/profiles/development-eu-west-2/devops2/vars
@@ -1,0 +1,16 @@
+account_name = "development"
+environment = "devops2"
+
+instance_specifications = {
+  "eu-west-2a" = {
+    "1" = {}
+  }
+  "eu-west-2b" = {
+    "2" = {}
+  }
+  "eu-west-2c" = {
+    "3" = {}
+  }
+}
+
+route53_available = true


### PR DESCRIPTION
Required changes for rolling out the prometheus kafka exporter.

Add instance template path for managing user_data. Changes have been made in terraform-modules repo so the version requires updating.

Add Devops2 environment profile configuration.