### PR TITLE
Rename prometheus jobs and add additional network dashboard

### DIFF
--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -51,7 +51,7 @@
     ("slack_notification" not in alert_list)
   no_log: True
 
-- name: Create logging nodes dashboard
+- name: Create kafka3 monitoring dashboards
   uri:
     url: "{{ grafana_url }}/api/dashboards/db"
     method: POST

--- a/roles/grafana/templates/kafka3_dashboard.json.j2
+++ b/roles/grafana/templates/kafka3_dashboard.json.j2
@@ -1210,7 +1210,7 @@
         "dashLength": 10,
         "dashes": false,
         "datasource": "kafka3-{{ item.environment }}",
-        "description": "Kafka3 {{ item.environment }} broker network traffic",
+        "description": "Kafka3 {{ item.environment }} broker network traffic received",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1278,7 +1278,7 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Broker Network Traffic",
+        "title": "Broker Network Traffic (Rx)",
         "tooltip": {
           "shared": true,
           "sort": 0,
@@ -1321,7 +1321,7 @@
         "dashLength": 10,
         "dashes": false,
         "datasource": "kafka3-{{ item.environment }}",
-        "description": "Kafka3 {{ item.environment }} zookeeper network traffic",
+        "description": "Kafka3 {{ item.environment }} zookeeper network traffic received",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1337,7 +1337,7 @@
           "y": 24
         },
         "hiddenSeries": false,
-        "id": 26,
+        "id": 38,
         "legend": {
           "avg": false,
           "current": false,
@@ -1389,7 +1389,229 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Zookeeper Network Traffic",
+        "title": "Zookeeper Network Traffic (Rx)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "kafka3-{{ item.environment }}",
+        "description": "Kafka3 {{ item.environment }} broker network traffic transmitted",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 8,
+          "x": 0,
+          "y": 30
+        },
+        "hiddenSeries": false,
+        "id": 37,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/.*/",
+            "color": "#E0B400"
+          },
+          {
+            "alias": "average",
+            "color": "#FFF899"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_transmit_bytes_total{job=\"broker-node-metrics\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} transmit ({{private_ip}}){% endraw %}",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(irate(node_network_transmit_bytes_total{job=\"broker-node-metrics\",device=\"eth0\"}[5m]))",
+            "interval": "",
+            "legendFormat": "average",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Broker Network Traffic (Tx)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "kafka3-{{ item.environment }}",
+        "description": "Kafka3 {{ item.environment }} zookeeper network traffic transmitted",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 8,
+          "x": 8,
+          "y": 30
+        },
+        "hiddenSeries": false,
+        "id": 26,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/.*/",
+            "color": "#1F60C4"
+          },
+          {
+            "alias": "average",
+            "color": "#C0D8FF"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_transmit_bytes_total{job=\"zookeeper-node-metrics\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} transmit ({{private_ip}}){% endraw %}",
+            "refId": "A"
+          },
+          {
+            "expr": "avg(irate(node_network_transmit_bytes_total{job=\"zookeeper-node-metrics\",device=\"eth0\"}[5m]))",
+            "interval": "",
+            "legendFormat": "average",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Zookeeper Network Traffic (Tx)",
         "tooltip": {
           "shared": true,
           "sort": 0,

--- a/roles/grafana/templates/kafka3_dashboard.json.j2
+++ b/roles/grafana/templates/kafka3_dashboard.json.j2
@@ -119,13 +119,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"broker\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"broker-node-metrics\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"broker\",mode=\"idle\"}[5m])) * 100))",
+            "expr": "avg(100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"broker-node-metrics\",mode=\"idle\"}[5m])) * 100))",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -279,13 +279,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"zookeeper\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"zookeeper-node-metrics\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"zookeeper\",mode=\"idle\"}[5m])) * 100))",
+            "expr": "avg(100 - (avg by (private_ip) (rate(node_cpu_seconds_total{job=\"zookeeper-node-metrics\",mode=\"idle\"}[5m])) * 100))",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -398,13 +398,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{job=\"broker\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{job=\"broker-node-metrics\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_memory_MemFree_bytes{job=\"broker\"}/1073741824)",
+            "expr": "avg(node_memory_MemFree_bytes{job=\"broker-node-metrics\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -510,13 +510,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{job=\"zookeeper\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{job=\"zookeeper-node-metrics\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_memory_MemFree_bytes{job=\"zookeeper\"}/1073741824)",
+            "expr": "avg(node_memory_MemFree_bytes{job=\"zookeeper-node-metrics\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -662,13 +662,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{job=\"broker\", device=\"/dev/nvme0n1p1\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{job=\"broker-node-metrics\", device=\"/dev/nvme0n1p1\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_filesystem_avail_bytes{job=\"broker\", device=\"/dev/nvme0n1p1\"}/1073741824)",
+            "expr": "avg(node_filesystem_avail_bytes{job=\"broker-node-metrics\", device=\"/dev/nvme0n1p1\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -822,13 +822,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{job=\"zookeeper\", device=\"/dev/nvme0n1p1\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{job=\"zookeeper-node-metrics\", device=\"/dev/nvme0n1p1\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_filesystem_avail_bytes{job=\"zookeeper\", device=\"/dev/nvme0n1p1\"}/1073741824)",
+            "expr": "avg(node_filesystem_avail_bytes{job=\"zookeeper-node-metrics\", device=\"/dev/nvme0n1p1\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -982,13 +982,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{job=\"broker\", mountpoint=\"/data/kafka\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{job=\"broker-node-metrics\", mountpoint=\"/data/kafka\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_filesystem_avail_bytes{job=\"broker\", mountpoint=\"/data/kafka\"}/1073741824)",
+            "expr": "avg(node_filesystem_avail_bytes{job=\"broker-node-metrics\", mountpoint=\"/data/kafka\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -1142,13 +1142,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{job=\"zookeeper\", mountpoint=\"/data/zookeeper\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{job=\"zookeeper-node-metrics\", mountpoint=\"/data/zookeeper\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{private_ip}}{% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(node_filesystem_avail_bytes{job=\"zookeeper\", mountpoint=\"/data/zookeeper\"}/1073741824)",
+            "expr": "avg(node_filesystem_avail_bytes{job=\"zookeeper-node-metrics\", mountpoint=\"/data/zookeeper\"}/1073741824)",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -1262,13 +1262,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{job=\"broker\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{job=\"broker-node-metrics\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{private_ip}}){% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(irate(node_network_receive_bytes_total{job=\"broker\",device=\"eth0\"}[5m]))",
+            "expr": "avg(irate(node_network_receive_bytes_total{job=\"broker-node-metrics\",device=\"eth0\"}[5m]))",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"
@@ -1373,13 +1373,13 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{job=\"zookeeper\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{job=\"zookeeper-node-metrics\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{private_ip}}){% endraw %}",
             "refId": "A"
           },
           {
-            "expr": "avg(irate(node_network_receive_bytes_total{job=\"zookeeper\",device=\"eth0\"}[5m]))",
+            "expr": "avg(irate(node_network_receive_bytes_total{job=\"zookeeper-node-metrics\",device=\"eth0\"}[5m]))",
             "interval": "",
             "legendFormat": "average",
             "refId": "B"


### PR DESCRIPTION
Renames the previous jobs to be more descriptive and to match the changes carried out in `prometheus.yml`.

Add a new dashboard for network transmitted
 