### PR TITLE
Update prometheus jobs with additional labels

### DIFF
--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -33,6 +33,8 @@ write_files:
               target_label: hostname
             - source_labels: [__meta_ec2_tag_Name]
               target_label: name
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
 
         - job_name: broker-node-metrics
           scrape_interval: 60s
@@ -50,6 +52,10 @@ write_files:
                 - name: tag:ServiceSubType
                   values: [kafka]
           relabel_configs:
+            - source_labels: [__meta_ec2_tag_HostName]
+              target_label: hostname
+            - source_labels: [__meta_ec2_tag_Name]
+              target_label: name
             - source_labels: [__meta_ec2_private_ip]
               target_label: private_ip
 
@@ -69,5 +75,9 @@ write_files:
                 - name: tag:ServiceSubType
                   values: [zookeeper]
           relabel_configs:
+            - source_labels: [__meta_ec2_tag_HostName]
+              target_label: hostname
+            - source_labels: [__meta_ec2_tag_Name]
+              target_label: name
             - source_labels: [__meta_ec2_private_ip]
               target_label: private_ip


### PR DESCRIPTION
Adds additional labels for the current jobs.
In return we will have, hostname, name and private_ip available.

These will be used in the legend on the dashboard to easily identify instances by name and ip address.