### PR TITLE
Allow admin and automation access to staging

### DIFF
--- a/groups/kafka/profiles/staging-eu-west-2/staging/vars
+++ b/groups/kafka/profiles/staging-eu-west-2/staging/vars
@@ -1,5 +1,6 @@
 account_name = "staging"
-allow_broker_automation_access = false
+allow_broker_administration_access = true
+allow_broker_automation_access = true
 default_instance_type = "m5.large"
 environment = "staging"
 


### PR DESCRIPTION
Allow admin and automation access to staging. 

This was requested a while ago by the testers but not committed at the time.