### PR TITLE
Allow admin access to common kafka stack

### DIFF
--- a/groups/kafka/profiles/development-eu-west-2/common/vars
+++ b/groups/kafka/profiles/development-eu-west-2/common/vars
@@ -1,4 +1,5 @@
 account_name = "development"
+allow_broker_administration_access = true
 allow_broker_automation_access = true
 environment = "common"
 


### PR DESCRIPTION
Allow admin access to common Kafka stack so devs/testers can look at consumed messages