### PR TITLE
Update kafka3 datasource dashboard with new slack uid

### DIFF
--- a/roles/grafana/templates/kafka3_dashboard.json.j2
+++ b/roles/grafana/templates/kafka3_dashboard.json.j2
@@ -58,7 +58,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },
@@ -218,7 +218,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },
@@ -601,7 +601,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },
@@ -761,7 +761,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },
@@ -921,7 +921,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },
@@ -1081,7 +1081,7 @@
           "noDataState": "alerting",
           "notifications": [
             {
-              "uid": "slack_notification"
+              "uid": "slack_infrastructure_notification"
             }
           ]
         },


### PR DESCRIPTION
Updated the slack channel uid once adding error and lag alert channels for consistency and therefore this template will need the new uid specified.