### PR TITLE
Set the uid and title via a variable in the pipeline instead of generating using the environment. 

### DIFF
--- a/roles/grafana/templates/insolvency.json.j2
+++ b/roles/grafana/templates/insolvency.json.j2
@@ -415,7 +415,7 @@
     },
     "timepicker": {},
     "timezone": "",
-    "title": "insolvency",
-    "uid": "{{ item.environment }}-kafka3-insolvency"
+    "title": "{{ item.grafana_dashboard_uid }}",
+    "uid": "{{ item.grafana_dashboard_uid }}"
   }
 }


### PR DESCRIPTION
The development Kafka stack is common and is a target for the scrum environments to create their topics which is prefixed with their environment name which is the method used to differentiate between their topic and a different scrum teams topic. For example Insolvency may have `cidev-insolvency-delta` and `rebel1-insolvency-delta`. So we would need to differentiate between multiple dashboards for insolvency and the old approach would clash on the uid/title.

In addition to the clash the environment variable being set is for use for the Grafana instance and not the prefixed topics environment so this would be incorrect. Setting the variable will allow us to spin up multiple dashboards for projects and environments and they will contain a unique ID and title relevant to the dashboard being provisioned.